### PR TITLE
Explicitly required v0.3.0 of webpack-dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "redux": "^3.5.2",
     "redux-thunk": "latest",
     "webpack": "^3.4.1",
-    "webpack-dashboard": "latest",
+    "webpack-dashboard": "0.3.0",
     "webpack-dev-server": "^2.4.5"
   }
 }


### PR DESCRIPTION
Latest version of webpack-dashboard [here](https://github.com/FormidableLabs/webpack-dashboard/releases) is 1.0.0 and this was breaking our `npm run dev` tasks with:

```
TypeError: Cannot read property 'sizes' of undefined
    at groupModules (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/utils/format-modules.js:75:19)
    at formatModules (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/utils/format-modules.js:94:22)
    at Object.callback (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/dashboard/index.js:186:34)
    at Listbar.selectTab (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/blessed/lib/widgets/listbar.js:399:18)
    at Dashboard.setSizes (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/dashboard/index.js:193:22)
    at Object.sizes (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/dashboard/index.js:78:18)
    at actionForMessageType (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/dashboard/index.js:90:28)
    at Array.forEach (native)
    at Dashboard.setData (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/dashboard/index.js:99:8)
    at Socket.socket.on.message (/Users/claireparker/Dev/react-fredhopper-magepack/node_modules/webpack-dashboard/bin/webpack-dashboard.js:68:21)```

Setting to an older version fixed the issue.